### PR TITLE
feat: fix bugs on functions rgb2int and int2rgb

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,22 @@
+name: Create GitHub release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,49 @@
+name: Publish packages to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint code
+        run: pnpm lint
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Publish package to npm
+        run: pnpm publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-parser",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "AutoCAD MText parser written in TypeScript",
   "type": "module",
   "main": "dist/parser.cjs.js",
@@ -17,12 +17,13 @@
     "build": "vite build",
     "build:example": "vite build --config vite.config.ts --mode example",
     "build:types": "tsc --emitDeclarationOnly",
-    "test": "jest",
     "example": "npm run build && npm run build:example && node dist/node/example.cjs.js",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
     "lint": "eslint ./src --ext .ts",
-    "lint:fix": "eslint ./src --ext .ts --fix"
+    "lint:fix": "eslint ./src --ext .ts --fix",
+    "release": "node tools/release.mjs",
+    "test": "jest"
   },
   "keywords": [
     "autocad",

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -16,17 +16,17 @@ import {
 describe('Utility Functions', () => {
   describe('rgb2int', () => {
     it('converts RGB tuple to integer', () => {
-      expect(rgb2int([255, 0, 0])).toBe(0x0000ff);
+      expect(rgb2int([255, 0, 0])).toBe(0xff0000);
       expect(rgb2int([0, 255, 0])).toBe(0x00ff00);
-      expect(rgb2int([0, 0, 255])).toBe(0xff0000);
+      expect(rgb2int([0, 0, 255])).toBe(0x0000ff);
     });
   });
 
   describe('int2rgb', () => {
     it('converts integer to RGB tuple', () => {
-      expect(int2rgb(0x0000ff)).toEqual([255, 0, 0]);
+      expect(int2rgb(0xff0000)).toEqual([255, 0, 0]);
       expect(int2rgb(0x00ff00)).toEqual([0, 255, 0]);
-      expect(int2rgb(0xff0000)).toEqual([0, 0, 255]);
+      expect(int2rgb(0x0000ff)).toEqual([0, 0, 255]);
     });
   });
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -214,7 +214,7 @@ const CHAR_TO_ALIGN: Record<string, MTextParagraphAlignment> = {
  */
 export function rgb2int(rgb: RGB): number {
   const [r, g, b] = rgb;
-  return (b << 16) | (g << 8) | r;
+  return (r << 16) | (g << 8) | b;
 }
 
 /**
@@ -223,9 +223,9 @@ export function rgb2int(rgb: RGB): number {
  * @returns RGB color tuple
  */
 export function int2rgb(value: number): RGB {
-  const r = value & 0xff;
+  const r = (value >> 16) & 0xff;
   const g = (value >> 8) & 0xff;
-  const b = (value >> 16) & 0xff;
+  const b = value & 0xff;
   return [r, g, b];
 }
 

--- a/tools/release.mjs
+++ b/tools/release.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
+function run(cmd) {
+  return execSync(cmd, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+/**
+ * Parse vX.Y.Z
+ */
+function parseVersion(tag) {
+  const m = tag.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+  };
+}
+
+/**
+ * Find latest vX.Y.Z tag (sorted by semver, not by time)
+ */
+function findLatestTag() {
+  const output = run('git tag --list "v*.*.*"');
+  if (!output) return null;
+
+  const tags = output
+    .split('\n')
+    .map(t => ({ tag: t, v: parseVersion(t) }))
+    .filter(t => t.v !== null);
+
+  if (tags.length === 0) return null;
+
+  tags.sort((a, b) => {
+    if (a.v.major !== b.v.major) return b.v.major - a.v.major;
+    if (a.v.minor !== b.v.minor) return b.v.minor - a.v.minor;
+    return b.v.patch - a.v.patch;
+  });
+
+  return tags[0].tag;
+}
+
+/**
+ * Main
+ */
+let version = process.argv[2];
+
+if (!version) {
+  const latestTag = findLatestTag();
+  if (!latestTag) {
+    fail('No existing vX.Y.Z tag found, please specify a version explicitly.');
+  }
+
+  const v = parseVersion(latestTag);
+  version = `${v.major}.${v.minor}.${v.patch + 1}`;
+
+  console.log(`ℹ️  No version provided, auto-incrementing patch: ${latestTag} → v${version}`);
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  fail(`Invalid version "${version}". Expected format: X.Y.Z`);
+}
+
+const tag = `v${version}`;
+
+/**
+ * Safety checks
+ */
+try {
+  run(`git rev-parse --verify refs/tags/${tag}`);
+  fail(`Tag ${tag} already exists.`);
+} catch {
+  // tag does not exist → OK
+}
+
+try {
+  const branch = run('git branch --show-current');
+  if (branch !== 'main') {
+    fail(`Current branch is "${branch}". Please release from "main".`);
+  }
+} catch {
+  // non-fatal
+}
+
+const status = run('git status --porcelain');
+if (status) {
+  fail('Working tree is not clean. Please commit or stash changes.');
+}
+
+/**
+ * Create & push annotated tag
+ */
+console.log(`🚀 Creating tag ${tag}`);
+
+run(`git tag -a ${tag} -m "release: release ${tag}"`);
+run(`git push origin ${tag}`);
+
+console.log(`✅ Release tag ${tag} pushed successfully`);


### PR DESCRIPTION
## Summary

This PR fixes incorrect RGB integer conversion behavior and adds a release workflow for GitHub and npm.

## Changes

- fix `rgb2int` to encode colors in `0xRRGGBB` order
- fix `int2rgb` to decode integers from `0xRRGGBB` correctly
- update unit tests for color conversion utilities
- add `tools/release.mjs` to create and push semver tags
- add GitHub Actions workflow to publish the package to npm on `v*` tags
- add GitHub Actions workflow to create GitHub Releases on `v*` tags
- bump package version from `1.3.2` to `1.3.3`
- add `npm run release` script

## Why

The previous color conversion logic swapped red and blue channels, which caused incorrect conversion results between RGB tuples and integer color values.

This PR also standardizes the release process so tagged releases can publish to npm and generate GitHub Releases automatically.

## Testing

- updated existing tests for `rgb2int` and `int2rgb`
- existing test suite runs through `pnpm test`

## Notes

- release workflows are triggered by tags matching `v*`
- npm publishing requires `NPM_TOKEN` to be configured in repository secrets
