### PR TITLE
feat: add yieldPercentSymbols option to emit PERCENT_SYMBOL tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-parser",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "AutoCAD MText parser written in TypeScript",
   "type": "module",
   "main": "dist/parser.js",

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -746,6 +746,87 @@ describe('MTextParser', () => {
         expect(tokens[0].data).toBe('Text');
       });
     });
+
+    describe('yieldPercentSymbols', () => {
+      it('emits PERCENT_SYMBOL tokens for %%c, %%d, and %%p', () => {
+        const parser = new MTextParser('%%c%%d%%p', undefined, {
+          yieldPercentSymbols: true,
+        });
+        const tokens = Array.from(parser.parse());
+        expect(tokens).toHaveLength(3);
+        expect(tokens[0]).toMatchObject({
+          type: TokenType.PERCENT_SYMBOL,
+          data: { kind: 'named', code: 'c', char: 'Ø' },
+        });
+        expect(tokens[1]).toMatchObject({
+          type: TokenType.PERCENT_SYMBOL,
+          data: { kind: 'named', code: 'd', char: '°' },
+        });
+        expect(tokens[2]).toMatchObject({
+          type: TokenType.PERCENT_SYMBOL,
+          data: { kind: 'named', code: 'p', char: '±' },
+        });
+      });
+
+      it('emits PERCENT_SYMBOL for numeric %%ddd codes', () => {
+        const parser = new MTextParser('%%130%%132', undefined, {
+          yieldPercentSymbols: true,
+        });
+        const tokens = Array.from(parser.parse());
+        expect(tokens).toHaveLength(2);
+        expect(tokens[0]).toMatchObject({
+          type: TokenType.PERCENT_SYMBOL,
+          data: {
+            kind: 'numeric',
+            charCode: 130,
+            char: String.fromCharCode(130),
+          },
+        });
+        expect(tokens[1]).toMatchObject({
+          type: TokenType.PERCENT_SYMBOL,
+          data: {
+            kind: 'numeric',
+            charCode: 132,
+            char: String.fromCharCode(132),
+          },
+        });
+      });
+
+      it('emits PERCENT_SYMBOL for literal percent (%%%)', () => {
+        const parser = new MTextParser('%%%', undefined, {
+          yieldPercentSymbols: true,
+        });
+        const tokens = Array.from(parser.parse());
+        expect(tokens).toHaveLength(1);
+        expect(tokens[0]).toMatchObject({
+          type: TokenType.PERCENT_SYMBOL,
+          data: { kind: 'literal', char: '%' },
+        });
+      });
+
+      it('interleaves WORD and PERCENT_SYMBOL tokens', () => {
+        const parser = new MTextParser('A%%cB', undefined, {
+          yieldPercentSymbols: true,
+        });
+        const tokens = Array.from(parser.parse());
+        expect(tokens).toHaveLength(3);
+        expect(tokens[0].type).toBe(TokenType.WORD);
+        expect(tokens[0].data).toBe('A');
+        expect(tokens[1].type).toBe(TokenType.PERCENT_SYMBOL);
+        expect(tokens[1].data).toEqual({ kind: 'named', code: 'c', char: 'Ø' });
+        expect(tokens[2].type).toBe(TokenType.WORD);
+        expect(tokens[2].data).toBe('B');
+      });
+
+      it('preserves default WORD expansion when yieldPercentSymbols is false', () => {
+        const parser = new MTextParser('%%c', undefined, {
+          yieldPercentSymbols: false,
+        });
+        const tokens = Array.from(parser.parse());
+        expect(tokens[0].type).toBe(TokenType.WORD);
+        expect(tokens[0].data).toBe('Ø');
+      });
+    });
   });
 
   describe('GBK character encoding', () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -22,7 +22,34 @@ export enum TokenType {
   WRAP_AT_DIMLINE = 8,
   /** Properties changed token with string data (full command) */
   PROPERTIES_CHANGED = 9,
+  /** AutoCAD percent-sign symbol code (`%%c`, `%%d`, `%%p`, `%%ddd`, `%%%`) */
+  PERCENT_SYMBOL = 10,
 }
+
+/**
+ * AutoCAD percent-sign symbol emitted when {@link MTextParserOptions.yieldPercentSymbols}
+ * is enabled.
+ */
+export type PercentSymbolData =
+  | {
+      kind: 'named';
+      /** Percent code letter: `%%c`, `%%d`, or `%%p`. */
+      code: 'c' | 'd' | 'p';
+      /** Unicode expansion used for display (e.g. `%%c` → `Ø`). */
+      char: string;
+    }
+  | {
+      kind: 'numeric';
+      /** Decimal code from `%%ddd` (0–255). */
+      charCode: number;
+      /** `String.fromCharCode(charCode)`. */
+      char: string;
+    }
+  | {
+      kind: 'literal';
+      /** Literal percent from `%%%`. */
+      char: '%';
+    };
 
 /**
  * Represents a factor value that can be either absolute or relative.
@@ -102,6 +129,7 @@ export type TokenData = {
   [TokenType.NEW_COLUMN]: null;
   [TokenType.WRAP_AT_DIMLINE]: null;
   [TokenType.PROPERTIES_CHANGED]: ChangedProperties;
+  [TokenType.PERCENT_SYMBOL]: PercentSymbolData;
 };
 
 /**
@@ -439,6 +467,12 @@ export interface MTextParserOptions {
    */
   resetParagraphParameters?: boolean;
   /**
+   * Whether to emit {@link TokenType.PERCENT_SYMBOL} tokens for AutoCAD `%%` symbol
+   * codes instead of expanding them into {@link TokenType.WORD} characters.
+   * @default false
+   */
+  yieldPercentSymbols?: boolean;
+  /**
    * Custom decoder function for MIF (Multibyte Interchange Format) codes.
    * If provided, this function will be used instead of the default decodeMultiByteChar.
    * The function receives the hex code string and should return the decoded character.
@@ -466,6 +500,7 @@ export class MTextParser {
   private continueStroke: boolean = false;
   private yieldPropertyCommands: boolean;
   private resetParagraphParameters: boolean;
+  private yieldPercentSymbols: boolean;
   private inStackContext: boolean = false;
   private mifDecoder: (hex: string) => string;
   private mifCodeLength: 4 | 5 | 'auto';
@@ -482,6 +517,7 @@ export class MTextParser {
     this.ctxStack = new ContextStack(initialCtx);
     this.yieldPropertyCommands = options.yieldPropertyCommands ?? false;
     this.resetParagraphParameters = options.resetParagraphParameters ?? false;
+    this.yieldPercentSymbols = options.yieldPercentSymbols ?? false;
     this.mifDecoder = options.mifDecoder ?? this.decodeMultiByteChar.bind(this);
     this.mifCodeLength = options.mifCodeLength ?? 'auto';
   }
@@ -1161,6 +1197,22 @@ export class MTextParser {
   }
 
   /**
+   * Builds {@link PercentSymbolData} for a recognized `%%` code letter.
+   */
+  private buildPercentSymbolData(
+    code: string,
+    specialChar: string
+  ): PercentSymbolData | null {
+    if (code === 'c' || code === 'd' || code === 'p') {
+      return { kind: 'named', code, char: specialChar };
+    }
+    if (code === '%') {
+      return { kind: 'literal', char: '%' };
+    }
+    return null;
+  }
+
+  /**
    * Parse MText content into tokens
    * @yields MTextToken objects
    */
@@ -1168,6 +1220,7 @@ export class MTextParser {
     const wordToken = TokenType.WORD;
     const spaceToken = TokenType.SPACE;
     let followupToken: TokenType | null = null;
+    let followupData: TokenData[TokenType] | undefined;
 
     function resetParagraph(ctx: MTextContext): Partial<ParagraphProperties> {
       const prev = { ...ctx.paragraph };
@@ -1306,6 +1359,17 @@ export class MTextParser {
           const specialChar = SPECIAL_CHAR_ENCODING[code];
           if (specialChar) {
             this.scanner.consume(3);
+            if (this.yieldPercentSymbols) {
+              const symbolData = this.buildPercentSymbolData(code, specialChar);
+              if (symbolData) {
+                if (word) {
+                  followupToken = TokenType.PERCENT_SYMBOL;
+                  followupData = symbolData;
+                  return [wordToken, word];
+                }
+                return [TokenType.PERCENT_SYMBOL, symbolData];
+              }
+            }
             word += specialChar;
             continue;
           } else {
@@ -1319,6 +1383,19 @@ export class MTextParser {
             if (digits.every(d => d >= '0' && d <= '9')) {
               const charCode = Number.parseInt(digits.join(''), 10);
               this.scanner.consume(5);
+              if (this.yieldPercentSymbols) {
+                const symbolData: PercentSymbolData = {
+                  kind: 'numeric',
+                  charCode,
+                  char: String.fromCharCode(charCode),
+                };
+                if (word) {
+                  followupToken = TokenType.PERCENT_SYMBOL;
+                  followupData = symbolData;
+                  return [wordToken, word];
+                }
+                return [TokenType.PERCENT_SYMBOL, symbolData];
+              }
               word += String.fromCharCode(charCode);
             } else {
               // Skip invalid special character codes
@@ -1431,8 +1508,13 @@ export class MTextParser {
           }
         }
         if (followupToken) {
-          yield new MTextToken(followupToken, this.ctxStack.current.copy(), null);
+          yield new MTextToken(
+            followupToken,
+            this.ctxStack.current.copy(),
+            followupData ?? null
+          );
           followupToken = null;
+          followupData = undefined;
         }
       } else {
         break;


### PR DESCRIPTION
## Summary
- Add new `TokenType.PERCENT_SYMBOL` and `PercentSymbolData` type for structured AutoCAD `%%` symbol codes
- Add `yieldPercentSymbols` parser option (default `false`) to emit symbol tokens instead of expanding into `WORD` characters
- Support named codes (`%%c`, `%%d`, `%%p`), numeric codes (`%%ddd`), and literal percent (`%%%`)
- Add comprehensive tests and bump version to 1.5.0

## Test plan
- [x] Run `npm test` — `yieldPercentSymbols` test suite passes
- [ ] Verify default behavior unchanged when `yieldPercentSymbols` is `false` or omitted
- [ ] Confirm named, numeric, and literal `%%` codes emit correct `PERCENT_SYMBOL` token data

Made with [Cursor](https://cursor.com)