### PR TITLE
fix: parse AutoCAD \U+XXXX as exactly four hex digits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22.14.0
+          # npm@latest (Trusted Publishing) requires Node ^22.22.2+
+          node-version: 22.22.2
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
           scope: '@mlightcad'
 
       - name: Upgrade npm for Trusted Publishing
+        if: startsWith(github.ref, 'refs/tags/')
         run: npm install -g npm@latest
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-parser",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "AutoCAD MText parser written in TypeScript",
   "type": "module",
   "main": "dist/parser.js",

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1029,24 +1029,61 @@ describe('MTextParser', () => {
   });
 
   describe('Unicode (\\U+XXXX) escape sequences', () => {
-    it('decodes Unicode BMP and supplementary plane code points', () => {
+    it('decodes Unicode BMP code points with exactly four hex digits', () => {
       // Greek capital omega: \U+03A9
-      let parser = new MTextParser('Omega: \\U+03A9');
-      let tokens = Array.from(parser.parse());
+      const parser = new MTextParser('Omega: \\U+03A9');
+      const tokens = Array.from(parser.parse());
       expect(tokens[0].type).toBe(TokenType.WORD);
       expect(tokens[0].data).toBe('Omega:');
       expect(tokens[1].type).toBe(TokenType.SPACE);
       expect(tokens[2].type).toBe(TokenType.WORD);
       expect(tokens[2].data).toBe('Ω');
+    });
 
-      // Emoji: \U+1F600 (grinning face)
-      parser = new MTextParser('Smile: \\U+1F600');
-      tokens = Array.from(parser.parse());
+    it('decodes supplementary-plane characters via UTF-16 surrogate pairs', () => {
+      // Grinning face U+1F600 as AutoCAD surrogate pair \U+D83D\U+DE00
+      const parser = new MTextParser('Smile: \\U+D83D\\U+DE00');
+      const tokens = Array.from(parser.parse());
       expect(tokens[0].type).toBe(TokenType.WORD);
       expect(tokens[0].data).toBe('Smile:');
       expect(tokens[1].type).toBe(TokenType.SPACE);
       expect(tokens[2].type).toBe(TokenType.WORD);
       expect(tokens[2].data).toBe('😀');
+    });
+
+    it('preserves literal supplementary-plane characters in word tokens', () => {
+      const parser = new MTextParser('Hello 😀 world');
+      const tokens = Array.from(parser.parse());
+      expect(tokens[0].data).toBe('Hello');
+      expect(tokens[1].type).toBe(TokenType.SPACE);
+      expect(tokens[2].type).toBe(TokenType.WORD);
+      expect(tokens[2].data).toBe('😀');
+      expect([...(tokens[2].data as string)]).toEqual(['😀']);
+      expect(tokens[3].type).toBe(TokenType.SPACE);
+      expect(tokens[4].data).toBe('world');
+    });
+
+    it('does not consume hex digits after the four-digit code (cad-viewer#615)', () => {
+      const parser = new MTextParser('\\U+22054.0通');
+      const tokens = Array.from(parser.parse());
+      const words = tokens
+        .filter(token => token.type === TokenType.WORD)
+        .map(token => String(token.data))
+        .join('');
+      expect(words).toBe('∅4.0通');
+    });
+
+    it('treats a fifth hex digit after \\U+XXXX as literal text', () => {
+      // Non-standard \\U+1F600 must be read as U+1F60 + literal "0"
+      const parser = new MTextParser('Smile: \\U+1F600');
+      const tokens = Array.from(parser.parse());
+      expect(tokens[0].type).toBe(TokenType.WORD);
+      expect(tokens[0].data).toBe('Smile:');
+      expect(tokens[1].type).toBe(TokenType.SPACE);
+      expect(tokens[2].type).toBe(TokenType.WORD);
+      expect(tokens[2].data).toBe(String.fromCharCode(0x1f60));
+      expect(tokens[3].type).toBe(TokenType.WORD);
+      expect(tokens[3].data).toBe('0');
     });
 
     it('handles invalid or incomplete Unicode escapes as literal text', () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -601,6 +601,53 @@ export class MTextParser {
   }
 
   /**
+   * Parse an AutoCAD `\U+nnnn` escape after the leading `U` has been consumed.
+   *
+   * @remarks
+   * Exactly four hexadecimal digits are read. A high surrogate followed by
+   * another `\U+nnnn` low surrogate is combined into one supplementary-plane
+   * character (AutoCAD's encoding for code points above U+FFFF).
+   *
+   * @returns The decoded character, or `null` if the escape is incomplete
+   */
+  private parseUnicodeEscape(): string | null {
+    if (this.scanner.peek() !== '+') {
+      return null;
+    }
+
+    this.scanner.consume(1); // Consume the '+'
+    const hexMatch = this.scanner.tail.match(/^[0-9A-Fa-f]{4}/);
+    if (!hexMatch) {
+      this.scanner.consume(-1); // Rewind '+'
+      return null;
+    }
+
+    const codeUnit = parseInt(hexMatch[0], 16);
+    this.scanner.consume(hexMatch[0].length);
+
+    // High surrogate: combine with a following \U+ low-surrogate escape
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const pairMatch = this.scanner.tail.match(/^\\U\+([0-9A-Fa-f]{4})/);
+      if (pairMatch) {
+        const lowUnit = parseInt(pairMatch[1], 16);
+        if (lowUnit >= 0xdc00 && lowUnit <= 0xdfff) {
+          this.scanner.consume(pairMatch[0].length);
+          const codePoint =
+            ((codeUnit - 0xd800) << 10) + (lowUnit - 0xdc00) + 0x10000;
+          try {
+            return String.fromCodePoint(codePoint);
+          } catch {
+            return '▯';
+          }
+        }
+      }
+    }
+
+    // BMP code unit, or an unpaired surrogate kept as a UTF-16 unit
+    return String.fromCharCode(codeUnit);
+  }
+
+  /**
    * Push current context onto the stack
    */
   private pushCtx(): void {
@@ -1306,32 +1353,21 @@ export class MTextParser {
                 // If not a valid multi-byte code, treat as literal text
                 word += '\\M';
                 continue;
-              case 'U':
-                // Handle Unicode escape: \U+XXXX or \U+XXXXXXXX
-                if (this.scanner.peek() === '+') {
-                  this.scanner.consume(1); // Consume the '+'
-                  const hexMatch = this.scanner.tail.match(/^[0-9A-Fa-f]{4,8}/);
-                  if (hexMatch) {
-                    const hexCode = hexMatch[0];
-                    this.scanner.consume(hexCode.length);
-                    const codePoint = parseInt(hexCode, 16);
-                    let decodedChar = '';
-                    try {
-                      decodedChar = String.fromCodePoint(codePoint);
-                    } catch {
-                      decodedChar = '▯';
-                    }
-                    if (word) {
-                      return [wordToken, word];
-                    }
-                    return [wordToken, decodedChar];
+              case 'U': {
+                // AutoCAD \U+nnnn uses exactly four hex digits. Characters
+                // outside the BMP are encoded as two consecutive \U+XXXX
+                // UTF-16 surrogate escapes.
+                const decodedChar = this.parseUnicodeEscape();
+                if (decodedChar !== null) {
+                  if (word) {
+                    return [wordToken, word];
                   }
-                  // If no valid hex code found, rewind the '+' character
-                  this.scanner.consume(-1);
+                  return [wordToken, decodedChar];
                 }
                 // If not a valid Unicode code, treat as literal text
                 word += '\\U';
                 continue;
+              }
               default:
                 if (cmd) {
                   try {


### PR DESCRIPTION
## Summary
- Align `\U+XXXX` parsing with AutoCAD: read exactly four hex digits instead of 4–8, so trailing digits (e.g. `\U+22054.0通` → `∅4.0通`) are not consumed (cad-viewer#615).
- Decode supplementary-plane characters via consecutive UTF-16 surrogate escapes (`\U+D83D\U+DE00`).
- Bump package version to 1.5.1 and add regression tests.

## Test plan
- [x] `pnpm test` — 150 tests passed
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] GitHub CI green on this PR